### PR TITLE
Add `/dev/note` endpoint for live debugging

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -21,6 +21,7 @@ from api.blueprints.locations.controllers import locations
 from api.blueprints.languages.controllers import languages
 from api.blueprints.accounts.controllers import accounts
 from api.blueprints.upload.controllers import upload
+from api.blueprints.dev.controllers import dev
 
 
 api.register_blueprint(users, url_prefix='/user')
@@ -31,6 +32,7 @@ api.register_blueprint(locations, url_prefix='/location')
 api.register_blueprint(languages, url_prefix='/language')
 api.register_blueprint(accounts, url_prefix='/account')
 api.register_blueprint(upload, url_prefix='/upload')
+api.register_blueprint(dev, url_prefix='/dev')
 
 @api.after_request
 def add_custom_http_response_headers(response):

--- a/api/blueprints/dev/controllers.py
+++ b/api/blueprints/dev/controllers.py
@@ -1,0 +1,12 @@
+from flask import Blueprint
+import os
+
+dev = Blueprint('dev', __name__)
+
+@dev.route("/note")
+def get_note():
+    path = os.path.abspath(__file__)
+    dir = os.path.dirname(path)
+    note_path = os.path.join(dir, "note.txt")
+    with open(note_path, 'r') as file:
+        return file.read()

--- a/api/blueprints/dev/note.txt
+++ b/api/blueprints/dev/note.txt
@@ -1,0 +1,1 @@
+Your note here!

--- a/docs/source/developers.rst
+++ b/docs/source/developers.rst
@@ -1,0 +1,13 @@
+====================
+Guide for Developers
+====================
+
+Live Debugging
+==============
+
+The server can take a while to reflect changes, so if you want to check that the
+server has registered code changes and is serving the latest version, you can
+use the ``/dev/note`` endpoint. This endpoint serves the contents of
+``note.txt``, which you can change to display custom text. If that new text is
+displayed at that endpoint, you know the server has updated to reflect your
+changes.


### PR DESCRIPTION
The server can take time to reflect code changes, and if changes do not
affect the UI, it can be difficult to tell whether the server has
updated. This is especially troublesome when trying many potential fixes
for a bug without knowing that any will work.

To fix this problem, this commit adds a /dev/note endpoint that serves
up a custom "note" developers can change whenever they want to check
that the server has updated. In the future, perhaps debugging features
like this should be authenticated in some way.