### PR TITLE
Remove API Key Requirement

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,5 +1,4 @@
 from flask import Flask
-from .decorators import require_apikey
 from .credentials import sql
 from .extensions import mysql
 

--- a/api/blueprints/events/controllers.py
+++ b/api/blueprints/events/controllers.py
@@ -1,5 +1,4 @@
 from flask import Blueprint, request, g
-from api import require_apikey
 
 from api.blueprints.accounts.controllers import auth
 from api.blueprints.users.utils import _add_user_to_event
@@ -9,18 +8,15 @@ events = Blueprint('event', __name__)
 
 
 @events.route("/ping")
-@require_apikey
 def test():
     return "pong"
 
 @events.route("/<event_id>", methods=["GET"])
-@require_apikey
 def get_event(event_id):
     return get_by_id("events", event_id)
 
 
 @events.route("/<event_id>/reg", methods=["GET"])
-@require_apikey
 def get_event_registration(event_id):
     return get_paginated("SELECT * \
                           FROM event_registration \
@@ -32,7 +28,6 @@ def get_event_registration(event_id):
                           order_arg="max_registration_date")
 
 @events.route("/<event_id>/reg_count", methods=["GET"])
-@require_apikey
 def get_event_registration_count(event_id):
     query = "SELECT count(*) \
              as reg_count \
@@ -43,7 +38,6 @@ def get_event_registration_count(event_id):
 
 @events.route("/new", methods=["POST", "PUT"])
 @auth.login_required
-@require_apikey
 def make_new_event():
     req_obj = make_fake_request_obj(request)
     req_obj.form["id_host"] = g.user.id
@@ -78,7 +72,6 @@ def make_new_event():
 
 
 @events.route("/currentUserEventsByNetwork/<network_id>", methods=["GET"])
-@require_apikey
 @auth.login_required
 def user_events_for_network(network_id):
     user_id = g.user.id
@@ -92,7 +85,6 @@ def user_events_for_network(network_id):
                          order_arg="id")
 
 @events.route("/delete", methods=["DELETE"])
-@require_apikey
 @auth.login_required
 def delete_event():
     event_id = request.args.get('id')

--- a/api/blueprints/languages/controllers.py
+++ b/api/blueprints/languages/controllers.py
@@ -1,5 +1,4 @@
 from flask import Blueprint, jsonify, request, json, make_response
-from api import require_apikey
 from http import HTTPStatus
 from api.extensions import mysql
 from api.apiutils import *
@@ -8,19 +7,16 @@ languages = Blueprint('language', __name__)
 
 
 @languages.route("/ping")
-@require_apikey
 def test():
     return "pong"
 
 
 @languages.route("/<lang_id>", methods=["GET"])
-@require_apikey
 def get_language(lang_id):
     return get_by_id("languages", lang_id)
 
 
 @languages.route("/autocomplete", methods=["GET"])
-@require_apikey
 def get_language_autocomplete():
     input_text = request.args['input_text']
     if input_text is None:

--- a/api/blueprints/locations/controllers.py
+++ b/api/blueprints/locations/controllers.py
@@ -1,36 +1,30 @@
 from flask import Blueprint, request
-from api import require_apikey
 from api.apiutils import *
 
 locations = Blueprint('location', __name__)
 
 
 @locations.route("/ping")
-@require_apikey
 def test():
     return "pong"
 
 
 @locations.route("/countries/<country_id>", methods=["GET"])
-@require_apikey
 def get_country(country_id):
     return get_by_id("countries", country_id)
 
 
 @locations.route("/regions/<region_id>", methods=["GET"])
-@require_apikey
 def get_region(region_id):
     return get_by_id("regions", region_id)
 
 
 @locations.route("/cities/<city_id>", methods=["GET"])
-@require_apikey
 def get_city(city_id):
     return get_by_id("cities", city_id)
 
 
 @locations.route("/autocomplete", methods=["GET"])
-@require_apikey
 def autocomplete():
     # TODO: Have fancier queries. For now, we will just take advantage of regex, which functions as a "contains"
     # a direct format. This is a SQL injection vulnerability.

--- a/api/blueprints/networks/controllers.py
+++ b/api/blueprints/networks/controllers.py
@@ -1,5 +1,4 @@
 from flask import Blueprint, request, abort
-from api import require_apikey
 from api.apiutils import *
 from pymysql.err import IntegrityError
 
@@ -10,7 +9,6 @@ networks = Blueprint('network', __name__)
 
 
 @networks.route("/ping")
-@require_apikey
 def test():
     return "pong"
 
@@ -104,7 +102,6 @@ def get_column_value(db_connection,
 
 
 @networks.route("/networks", methods=["GET"])
-@require_apikey
 def get_networks(func_counter=0):
     # Validate that we have valid input data (we need a near_location).
     if "near_location" not in request.args:
@@ -169,13 +166,11 @@ def get_networks(func_counter=0):
 
 
 @networks.route("/<network_id>", methods=["GET"])
-@require_apikey
 def get_network(network_id):
     return get_by_id("networks", network_id)
 
 
 @networks.route("/<network_id>/posts", methods=["GET"])
-@require_apikey
 def get_network_posts(network_id):
     return get_paginated("SELECT * \
                          FROM posts \
@@ -188,7 +183,6 @@ def get_network_posts(network_id):
 
 
 @networks.route("/<network_id>/post_count", methods=["GET"])
-@require_apikey
 def get_network_post_count(network_id):
     query = "SELECT count(*) \
              as post_count \
@@ -198,7 +192,6 @@ def get_network_post_count(network_id):
 
 
 @networks.route("/<network_id>/events", methods=["GET"])
-@require_apikey
 def get_network_events(network_id):
     return get_paginated("SELECT * \
                           FROM events \
@@ -211,7 +204,6 @@ def get_network_events(network_id):
 
 
 @networks.route("/<network_id>/users", methods=["GET"])
-@require_apikey
 def get_network_users(network_id):
     return get_paginated("SELECT users.*, join_date \
                           FROM network_registration \
@@ -226,7 +218,6 @@ def get_network_users(network_id):
 
 
 @networks.route("/<network_id>/user_count", methods=["GET"])
-@require_apikey
 def get_network_user_count(network_id):
     query = "SELECT count(*) \
              as user_count \
@@ -236,7 +227,6 @@ def get_network_user_count(network_id):
 
 
 @networks.route("/new", methods=["POST"])
-@require_apikey
 def make_new_network(internal_req=None):
     content_fields = [
       'city_cur', 'id_city_cur', 'region_cur', 'id_region_cur', \

--- a/api/blueprints/posts/controllers.py
+++ b/api/blueprints/posts/controllers.py
@@ -1,5 +1,4 @@
 from flask import Blueprint, request, g
-from api import require_apikey
 from api.blueprints.accounts.controllers import auth
 from api.apiutils import *
 
@@ -7,22 +6,18 @@ from api.apiutils import *
 posts = Blueprint('post', __name__)
 
 @posts.route("/ping")
-@require_apikey
 def test():
     return "pong"
 
 @posts.route("/<post_id>", methods=["GET"])
-@require_apikey
 def get_post(post_id):
     return get_by_id("posts", post_id)
 
 @posts.route("/reply/<reply_id>", methods=["GET"])
-@require_apikey
 def get_post_reply(reply_id):
     return get_by_id("post_replies", reply_id)
 
 @posts.route("/<post_id>/replies", methods=["GET"])
-@require_apikey
 def get_post_replies(post_id):
     return get_paginated("SELECT post_replies.* \
                           FROM posts \
@@ -37,7 +32,6 @@ def get_post_replies(post_id):
 
 
 @posts.route("/<post_id>/reply_count", methods=["GET"])
-@require_apikey
 def get_post_reply_count(post_id):
     query = "SELECT count(*) \
              as reply_count \

--- a/api/blueprints/users/controllers.py
+++ b/api/blueprints/users/controllers.py
@@ -1,5 +1,4 @@
 from flask import Blueprint, request, g
-from api import require_apikey
 from hashlib import md5
 from pymysql.err import IntegrityError
 from api.blueprints.accounts.controllers import auth
@@ -15,7 +14,6 @@ Controller for all user endpoints. Check the Swagger spec for more information o
 
 
 @users.route("/ping")
-@require_apikey
 def test():
     return "pong"
 
@@ -84,7 +82,6 @@ def validate_new_user(form, content_fields):
 
 
 @users.route("/users", methods=["GET", "POST"])
-@require_apikey
 def users_query():
     if request.method == 'GET':
         return handle_users_get(request)
@@ -108,7 +105,6 @@ def users_query():
 
 
 @users.route("/update_user", methods=["PUT"])
-@require_apikey
 @auth.login_required
 def update_user():
     req_obj = make_fake_request_obj(request)
@@ -121,13 +117,11 @@ def update_user():
 
 
 @users.route("/<user_id>", methods=["GET"])
-@require_apikey
 def get_user(user_id):
     return get_by_id("users", user_id, ["email", "password"])
 
 
 @users.route("/<user_id>/networks", methods=["GET"])
-@require_apikey
 def get_user_networks(user_id):
     return get_paginated("SELECT networks.*, join_date \
                           FROM network_registration \
@@ -142,7 +136,6 @@ def get_user_networks(user_id):
 
 
 @users.route("/<user_id>/posts", methods=["GET"])
-@require_apikey
 def get_user_posts(user_id):
     return get_paginated("SELECT * \
                           FROM posts \
@@ -155,7 +148,6 @@ def get_user_posts(user_id):
 
 
 @users.route("/<user_id>/events", methods=["GET"])
-@require_apikey
 def get_user_events(user_id):
     return get_paginated("SELECT events.* \
                           FROM event_registration \
@@ -171,7 +163,6 @@ def get_user_events(user_id):
 
 @users.route("/joinEvent/<event_id>", methods=["POST"])
 @auth.login_required
-@require_apikey
 def add_user_to_event(event_id):
     # First, check that event and user are valid
     if not event_exists(event_id):
@@ -185,7 +176,6 @@ def add_user_to_event(event_id):
 
 @users.route("/leaveEvent/<event_id>", methods=["DELETE"])
 @auth.login_required
-@require_apikey
 def remove_user_from_event(event_id):
     if not event_exists(event_id):
         return make_response("Invalid Event Id", HTTPStatus.BAD_REQUEST)

--- a/api/decorators.py
+++ b/api/decorators.py
@@ -6,6 +6,16 @@ from .credentials import api
 
 
 def require_apikey(view_function):
+    """Force an endpoint to check that a valid api key has been submitted
+
+    This is intended to be used only for endpoints that should be only accessed
+    by apps that run on servers we control (e.g. FFB, not Android). This is
+    because a static API key can always be reverse-engineered out of an app
+    that runs on user's devices (e.g. Android phones)
+
+    :param view_function:
+    :return:
+    """
     @wraps(view_function)
     def decorated_func(*args, **kwargs):
         if request.args.get('key') and request.args.get('key') == api['key']:

--- a/docs/source/future-work.rst
+++ b/docs/source/future-work.rst
@@ -15,7 +15,6 @@ The API should provide endpoints for recommending Networks to a user.
 
 Security
 ========
-For development we began using an API key and we have been transitioning
-onto token-based authentication for some of the sensitive endpoints. This is
+We use token-based authentication for some of the sensitive endpoints. This is
 still not good practice -- something like Auth0 should be the end goal before
 the API is used to operate on sensitive data.


### PR DESCRIPTION
Sensitive methods are now protected by token-based user authentication, so the API key is no longer required. It was never very useful, as it could be reverse-engineered from the Android app. Now, we no longer have to worry about cycling that key if it is compromised.